### PR TITLE
Fix unfortunate spring-ai langchain4j dependency conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
         </dependency>
+        <!-- disabled by spring.ai.embedding.transformer.enabled=false -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-transformers-spring-boot-starter</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,7 @@ vaadin.whitelisted-packages = com.vaadin,org.vaadin,dev.hilla,com.example.applic
 spring.jpa.defer-datasource-initialization = true
 
 spring.ai.openai.api-key=${OPENAI_API_KEY}
-spring.ai.openai.chat.options.model=gpt-3.5-turbo
-#spring.ai.openai.chat.options.model=gpt-4-turbo-preview
+# spring.ai.openai.chat.options.model=gpt-3.5-turbo
+spring.ai.openai.chat.options.model=gpt-4-turbo-preview
 spring.ai.openai.chat.options.functions=getBookingDetails,changeBooking,cancelBooking
+spring.ai.embedding.transformer.enabled=false

--- a/src/main/resources/spring-ai/system-qa.st
+++ b/src/main/resources/spring-ai/system-qa.st
@@ -1,0 +1,16 @@
+You are a customer chat support agent of an airline named "Funnair".",
+Respond in a friendly, helpful, and joyful manner.
+Use the information from the DOCUMENTS section to provide accurate answers.
+Use the conversation history from the HISTORY section to provide accurate answers.
+Before providing information about a booking or cancelling a booking,
+you MUST always get the following information from the user:
+booking number, customer first name and last name.
+Before changing a booking you MUST ensure it is permitted by the terms.
+If there is a charge for the change, you MUST ask the user to consent before proceeding.
+Today is {current_date}.
+
+HISTORY:
+{history}
+
+DOCUMENTS:
+{documents}


### PR DESCRIPTION
Some dependency in langchain4j that uses ONNX activates the https://docs.spring.io/spring-ai/reference/api/embeddings/onnx.html

The problem is [here](https://github.com/spring-projects/spring-ai/blob/4c617e16b4eff459fa27c55fcbb3226e8e86932d/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/transformers/TransformersEmbeddingClientAutoConfiguration.java#L35).

We may have to add additional auto-conf activation guard on `TransformersEmbeddingClient.class` as well. 

Until then I've added the `spring-ai-transformers-spring-boot-starter` dependency so It can find the class, but disabled it `spring.ai.embedding.transformer.enabled=false` so it doesn't fight with OpenAI's embedding client.