### PR TITLE
Updated to LangChain4j 0.29.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <java.version>17</java.version>
         <hilla.version>2.5.6</hilla.version>
-        <langchain.version>0.28.0</langchain.version>
+        <langchain.version>0.29.0</langchain.version>
         <spring-ai.version>0.8.1</spring-ai.version>
     </properties>
 
@@ -111,39 +111,21 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- LangChain4j dependencies -->
         <dependency>
             <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j</artifactId>
-            <version>${langchain.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-open-ai</artifactId>
+            <artifactId>langchain4j-spring-boot-starter</artifactId>
             <version>${langchain.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-ollama</artifactId>
+            <artifactId>langchain4j-open-ai-spring-boot-starter</artifactId>
             <version>${langchain.version}</version>
         </dependency>
-
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
             <version>${langchain.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mapdb</groupId>
-            <artifactId>mapdb</artifactId>
-            <version>3.0.9</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/vaadin/marcus/langchain4j/LangChain4jAssistant.java
+++ b/src/main/java/org/vaadin/marcus/langchain4j/LangChain4jAssistant.java
@@ -4,7 +4,9 @@ import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.TokenStream;
 import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.spring.AiService;
 
+@AiService
 public interface LangChain4jAssistant {
 
     @SystemMessage("""

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,12 @@ spring.ai.openai.api-key=${OPENAI_API_KEY}
 spring.ai.openai.chat.options.model=gpt-4-turbo-preview
 spring.ai.openai.chat.options.functions=getBookingDetails,changeBooking,cancelBooking
 spring.ai.embedding.transformer.enabled=false
+
+# LangChain4j properties
+langchain4j.open-ai.streaming-chat-model.api-key=${OPENAI_API_KEY}
+langchain4j.open-ai.streaming-chat-model.model-name=gpt-4-turbo-preview
+langchain4j.open-ai.streaming-chat-model.log-requests=true
+langchain4j.open-ai.streaming-chat-model.log-responses=false
+logging.level.dev.langchain4j=DEBUG
+logging.level.dev.ai4j.openai4j=DEBUG
+logging.level.ai.djl=OFF


### PR DESCRIPTION
Hi @marcushellberg!
Do you mind if I update the code to use the latest ([0.29.0](https://github.com/langchain4j/langchain4j/releases/tag/0.29.0)) LangChain4j version and its latest features?

Changes in this PR:
- Using `langchain4j-open-ai-spring-boot-starter` auto-configuration instead of manually creating `OpenAiStreamingChatModel`
- Using [declarative AI Service](https://github.com/langchain4j/langchain4j-spring/pull/12) instead of manually creating `LangChain4jAssistant`
- Removed manual creation of `OpenAiTokenizer` as it is now automatically provided by `langchain4j-open-ai-spring-boot-starter`
- Changed the tokenizer configuration to split into segments of 50 tokens, because the current setting (200) does not split, as the `terms-of-service.txt` is only 162 tokens long
- Removed unnecessary ollama and mapdb dependencies

Please let me know if you want me to do any other adjustments.
Thank you!