### PR TITLE
Adding dependabot and automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: daily
+    target-branch: quarkus
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    target-branch: quarkus

--- a/.github/workflows/quarkus-build-test.yml
+++ b/.github/workflows/quarkus-build-test.yml
@@ -1,0 +1,61 @@
+name: Quarkus build and test
+
+on:
+  push:
+    branches:
+      - quarkus
+    paths-ignore:
+      - '**/*.md'
+      - '.github/dependabot.yml'
+      - '.github/workflows/quarkus-build-test.yml'
+  pull_request:
+    branches:
+      - quarkus
+    paths-ignore:
+      - '**/*.md'
+      - '.github/dependabot.yml'
+      - '.github/workflows/quarkus-build-test.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  jvm-build-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - '17'
+          - '21'
+    services:
+      ollama:
+        image: ollama/ollama
+        ports:
+          - 11434:11434
+    name: "jvm-build-test-${{ matrix.java }}"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: temurin
+          cache: maven
+
+      - name: Install playwright dependencies
+        run: |
+          sudo npx playwright install-deps
+          npx playwright install
+
+      - name: "build-test-jvm-java${{ matrix.java }}"
+        run: |
+          ./mvnw -B clean verify \
+            -Dquarkus.profile=ollama \
+            -Dquarkus.test.profile=ollama,test \
+            -Dquarkus.test.integration-test-profile=ollama,prod \
+            -Dquarkus.http.host=0.0.0.0 \
+            -Dmaven.compiler.release=${{ matrix.java }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This app is an AI-powered customer support application that:
 The application includes implementations for: 
 
 - [LangChain4j](https://github.com/langchain4j/langchain4j) in the `main` branch
+- [Quarkus](https://quarkus.io) in the `quarkus` branch (thanks to [@edeandrea](https://github.com/edeandrea)!)
 - [Spring AI](https://spring.io/projects/spring-ai/) in the `spring-ai` branch (thanks to [@tzolov](https://github.com/tzolov)!)
 - [Semantic Kernel](https://github.com/microsoft/semantic-kernel) in the `semantic-kernel` branch (thanks to [@sohamda](https://github.com/sohamda)!)
 
@@ -26,5 +27,5 @@ Run the app by running `Application.java` in your IDE or `mvn` in the command li
 ## Thanks
 This demo was inspired by the [LangChain4jCustomer Support Agent example](https://github.com/langchain4j/langchain4j-examples/tree/main/spring-boot-example/src/main/java/dev/langchain4j/example).
 
-I want to thank the LangChain4j, Spring AI, and Microsoft teams for their support in building this demo.
-Especially, I want to thank [@tzolov](https://github.com/tzolov) from The Spring AI team for his help in building the Spring AI implementation and [@sohamda](https://github.com/sohamda) from Microsoft for the Semantic Kernel implementation.
+I want to thank the LangChain4j, Quarkus, Spring AI, and Microsoft teams for their support in building this demo.
+Especially, I want to thank [@edeandrea](https://github.com/edeandrea) from the Quarkus team for his help in building the Quarkus implementation, [@tzolov](https://github.com/tzolov) from The Spring AI team for his help in building the Spring AI implementation and [@sohamda](https://github.com/sohamda) from Microsoft for the Semantic Kernel implementation.


### PR DESCRIPTION
Adding dependabot to keep Quarkus version up-to-date as well as some automation to run tests against Quarkus version.

**NOTE:** I did not add any of the other branches into the dependabot config because I wasn't sure which branches actually had tests that could verify the dependency updates don't break anything.

The Quarkus version does.